### PR TITLE
Support for optional statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,27 @@ Run this step until three statuses have succeeded on the current ref:
 
 See [action.yml](./action.yml) for a complete list of inputs and outputs.
 
+## Optional Statuses
+
+Elements in the `statuses` list may optionally be suffixed by any number of
+spaces and a `?`. This makes it acceptable if they never appear, but will still
+consider it a failure if they do appear as failed. This can be useful for matrix
+jobs whose statuses never appear in certain skipped scenarios, but we still want
+to account for them if they fail.
+
+Changing our usage example to:
+
+```yaml
+- uses: freckle/await-statuses-action@v1
+  statuses: |
+    test-this
+    build-that
+    other / thing (that) ?
+```
+
+This will result in us proceeding even if `other / thing (that)` never shows up,
+but if it ever shows up as failed, we will still fail immediately.
+
 ## Caveats
 
 This action works by querying the GitHub API for check-suites and their

--- a/dist/index.js
+++ b/dist/index.js
@@ -371,12 +371,25 @@ var FAILURE_CONCLUSIONS = [
     "timed_out",
 ];
 function checkRunsToStatuses(checkRuns, statusNames) {
+    var allStatusNames = [];
+    var waitForStatusNames = [];
+    for (var _i = 0, statusNames_1 = statusNames; _i < statusNames_1.length; _i++) {
+        var statusName = statusNames_1[_i];
+        if (statusName.endsWith("?")) {
+            var trimmed = statusName.slice(0, -1).trim();
+            allStatusNames.push(trimmed);
+        }
+        else {
+            allStatusNames.push(statusName);
+            waitForStatusNames.push(statusName);
+        }
+    }
     var all = [];
     var pending = [];
     var succeeded = [];
     var failed = [];
     checkRuns.forEach(function (run) {
-        if (!includes(statusNames, run.name)) {
+        if (!includes(allStatusNames, run.name)) {
             return;
         }
         all.push(run.name);
@@ -391,7 +404,7 @@ function checkRunsToStatuses(checkRuns, statusNames) {
         }
         throw new Error("Unexpected CheckRun conclusion: ".concat(run.conclusion, ". Must be one of ").concat(SUCCESS_CONCLUSIONS.concat(FAILURE_CONCLUSIONS).join(", ")));
     });
-    statusNames.forEach(function (name) {
+    waitForStatusNames.forEach(function (name) {
         if (!includes(all, name)) {
             pending.push(name);
         }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "license": "MIT",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@actions/exec": "^1.1.1",
     "@actions/github": "^5.1.1"
   },
   "devDependencies": {

--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -1,6 +1,3 @@
-import * as fs from "fs";
-import * as github from "@actions/github";
-
 import { checkRunsToStatuses } from "./status";
 import TEST_CHECK_RUNS from "./fixtures/megarepo-check-runs.json";
 

--- a/src/status.test.ts
+++ b/src/status.test.ts
@@ -13,3 +13,16 @@ test("For an example ref on megarepo", async () => {
   expect(statuses.succeeded).toEqual(["backend / test", "test-sql"]);
   expect(statuses.failed).toEqual(["platform-frontend / platform-image"]);
 });
+
+test("With optional statuses", async () => {
+  const statuses = checkRunsToStatuses(TEST_CHECK_RUNS, [
+    "backend / test",
+    "platform-frontend / platform-image?",
+    "test-sql",
+    "unknown-status ?",
+  ]);
+
+  // not waiting on unknown-status, but still failing on platform-image
+  expect(statuses.pending).toEqual([]);
+  expect(statuses.failed).toEqual(["platform-frontend / platform-image"]);
+});

--- a/src/status.ts
+++ b/src/status.ts
@@ -20,13 +20,26 @@ export function checkRunsToStatuses(
   checkRuns: CheckRun[],
   statusNames: string[]
 ): Statuses {
+  const allStatusNames: string[] = [];
+  const waitForStatusNames: string[] = [];
+
+  for (const statusName of statusNames) {
+    if (statusName.endsWith("?")) {
+      const trimmed = statusName.slice(0, -1).trim();
+      allStatusNames.push(trimmed);
+    } else {
+      allStatusNames.push(statusName);
+      waitForStatusNames.push(statusName);
+    }
+  }
+
   const all: string[] = [];
   const pending: string[] = [];
   const succeeded: string[] = [];
   const failed: string[] = [];
 
   checkRuns.forEach((run) => {
-    if (!includes(statusNames, run.name)) {
+    if (!includes(allStatusNames, run.name)) {
       return; // Not required, don't care
     }
 
@@ -53,8 +66,8 @@ export function checkRunsToStatuses(
     );
   });
 
-  // Add any statuses that we didn't see at all as pending
-  statusNames.forEach((name) => {
+  // Add statuses that we didn't see at all as pending
+  waitForStatusNames.forEach((name) => {
     if (!includes(all, name)) {
       pending.push(name);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,13 +15,6 @@
     "@actions/http-client" "^2.0.1"
     uuid "^8.3.2"
 
-"@actions/exec@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@actions/exec/-/exec-1.1.1.tgz#2e43f28c54022537172819a7cf886c844221a611"
-  integrity sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==
-  dependencies:
-    "@actions/io" "^1.0.1"
-
 "@actions/github@^5.1.1":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@actions/github/-/github-5.1.1.tgz#40b9b9e1323a5efcf4ff7dadd33d8ea51651bbcb"
@@ -46,11 +39,6 @@
   integrity sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==
   dependencies:
     tunnel "^0.0.6"
-
-"@actions/io@^1.0.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.1.1.tgz#4a157406309e212ab27ed3ae30e8c1d641686a66"
-  integrity sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA==
 
 "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7":
   version "7.16.7"


### PR DESCRIPTION
As per the README,

    Elements in the `statuses` list may optionally be suffixed by any
    number of spaces and a `?`. This makes it acceptable if they never
    appear, but will still consider it a failure if they do appear as
    failed. This can be useful for matrix jobs whose statuses never
    appear in certain skipped scenarios, but we still want to account
    for them if they fail.