### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/add-asana-comment.yml
+++ b/.github/workflows/add-asana-comment.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   link-asana-task:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/example.yaml
+++ b/.github/workflows/example.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   slow-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/freckle/await-statuses-action/security/code-scanning/8](https://github.com/freckle/await-statuses-action/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow primarily involves running commands and using the `actions/checkout` action, the minimal required permission is `contents: read`. This change ensures that the `GITHUB_TOKEN` has only the necessary permissions, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
